### PR TITLE
Fix Compatibility Issue: Implement Correct Type Hints in `NullLogger` for PHP 8.x

### DIFF
--- a/src/Logger/NullLogger.php
+++ b/src/Logger/NullLogger.php
@@ -19,39 +19,39 @@ use Psr\Log\LoggerInterface;
 
 class NullLogger implements LoggerInterface
 {
-    public function emergency($message, array $context = [])
+    public function emergency(string|\Stringable $message, array $context = []): void
     {
     }
 
-    public function alert($message, array $context = [])
+    public function alert(string|\Stringable $message, array $context = []): void
     {
     }
 
-    public function critical($message, array $context = [])
+    public function critical(string|\Stringable $message, array $context = []): void
     {
     }
 
-    public function error($message, array $context = [])
+    public function error(string|\Stringable $message, array $context = []): void
     {
     }
 
-    public function warning($message, array $context = [])
+    public function warning(string|\Stringable $message, array $context = []): void
     {
     }
 
-    public function notice($message, array $context = [])
+    public function notice(string|\Stringable $message, array $context = []): void
     {
     }
 
-    public function info($message, array $context = [])
+    public function info(string|\Stringable $message, array $context = []): void
     {
     }
 
-    public function debug($message, array $context = [])
+    public function debug(string|\Stringable $message, array $context = []): void
     {
     }
 
-    public function log($level, $message, array $context = [])
+    public function log($level, string|\Stringable $message, array $context = []): void
     {
     }
 }


### PR DESCRIPTION
This pull request addresses a compatibility issue encountered with Magento 2.4.7-p2 where the `NullLogger` class in the `202ecommerce/bridge-sdk` package does not implement the `LoggerInterface` methods with the correct type hints, leading to runtime errors.

**Issue Details:**
- **Steps to Reproduce:**
  1. Install Magento 2.4.7-p2 with the Bridge SDK (`202ecommerce/bridge-sdk`).
  2. Attempt to log any message using the `NullLogger` class.
  3. Observe the error due to incorrect method signatures.

- **Expected Behavior:**
  The `NullLogger` class should correctly implement the `LoggerInterface` methods with appropriate type hints for PHP 8.x compatibility.

- **Actual Behavior:**
  The `NullLogger` class currently uses method signatures without proper type hints, causing runtime errors in PHP 8.x.

**Fix:**
- Updated all `NullLogger` methods to include strict type hints, particularly for the `$message` parameter, which now accepts `string|\Stringable`.
- All methods now explicitly return `void` to align with PHP 8.x best practices.

**Impact:**
This fix ensures that the `NullLogger` class in the Bridge SDK is fully compatible with PHP 8.x and resolves the runtime errors caused by incorrect method signatures.

